### PR TITLE
Implements #5 - Adding additional optional attributes to the DirectedGraph root XML node.

### DIFF
--- a/src/DgmlBuilder/DgmlBuilder.csproj
+++ b/src/DgmlBuilder/DgmlBuilder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AssemblyName>OpenSoftware.DgmlBuilder</AssemblyName>
     <RootNamespace>OpenSoftware.DgmlTools</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -14,7 +14,7 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <Copyright>Merijn de Jonge</Copyright>
     <PackageTags>DGML modeling visualization</PackageTags>
-    <Version>1.13</Version>
+    <Version>1.14</Version>
     <FileVersion>1.1.0.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
@@ -24,10 +24,6 @@
 
   <ItemGroup>
     <Folder Include="Properties\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DgmlBuilder/Model/DirectedGraph.cs
+++ b/src/DgmlBuilder/Model/DirectedGraph.cs
@@ -18,6 +18,24 @@ namespace OpenSoftware.DgmlTools.Model
         [XmlAttribute]
         public bool DataVirtualized { get; set; }
 
+        [XmlAttribute]
+        public string Background { get; set; }
+
+        [XmlAttribute]
+        public GraphDirection GraphDirection { get; set; }
+
+        [XmlAttribute]
+        public Layout Layout { get; set; }
+
+        [XmlAttribute]
+        public byte NeighborhoodDistance { get; set; }
+
+        public bool ShouldSerializeGraphDirection() => GraphDirection != GraphDirection.Unspecified;
+
+        public bool ShouldSerializeLayout() => Layout != Layout.Unspecified;
+
+        public bool ShouldSerializeNeighborhoodDistance() => NeighborhoodDistance != 7;
+
         public List<Node> Nodes { get; set; }
         public List<Link> Links { get; set; }
         public List<Category> Categories { get; set; }

--- a/src/DgmlBuilder/Model/GraphDirection.cs
+++ b/src/DgmlBuilder/Model/GraphDirection.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenSoftware.DgmlTools.Model
+{
+    public enum GraphDirection
+    { 
+        Unspecified = 0,
+        TopToBottom, 
+        BottomToTop, 
+        LeftToRight, 
+        RightToLeft
+    }
+}

--- a/src/DgmlBuilder/Model/Layout.cs
+++ b/src/DgmlBuilder/Model/Layout.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OpenSoftware.DgmlTools.Model
+{
+    public enum Layout
+    {
+        Unspecified = 0,
+        None, 
+        Sugiyama, 
+        ForceDirected, 
+        DependencyMatrix
+    }
+}

--- a/src/examples/TypesVisualizer/Program.cs
+++ b/src/examples/TypesVisualizer/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Runtime.CompilerServices;
-using OpenSoftware.DgmlTools.Model;
 using OpenSoftware.DgmlTools.Reflection;
+using OpenSoftware.DgmlTools.Model;
 
 namespace OpenSoftware.DgmlTools
 {
@@ -20,7 +20,12 @@ namespace OpenSoftware.DgmlTools
             {
                 var types = loader.Load().ToArray();
                 var graph = TypesVisualizer.Types2Dgml(types);
-                graph.WriteToFile(@"../../class-diagram.dgml");
+
+                //graph.GraphDirection = GraphDirection.LeftToRight;
+                //graph.Layout = Layout.Sugiyama;
+                //graph.NeighborhoodDistance = 1;
+
+                graph.WriteToFile(@"../../../class-diagram.dgml");
             }
         }
     }

--- a/src/examples/TypesVisualizer/Properties/AssemblyInfo.cs
+++ b/src/examples/TypesVisualizer/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("TypesVisualizer")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("FEI Electron Optics")]
-[assembly: AssemblyProduct("TypesVisualizer")]
-[assembly: AssemblyCopyright("Copyright © FEI Electron Optics 2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e987b570-cc88-4001-aeba-c52c2038ef90")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/examples/TypesVisualizer/TypesVisualizer.csproj
+++ b/src/examples/TypesVisualizer/TypesVisualizer.csproj
@@ -1,68 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{E987B570-CC88-4001-AEBA-C52C2038EF90}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>OpenSoftware.DgmlTools</RootNamespace>
     <AssemblyName>OpenSoftware.DgmlTools.TypesVisualizer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>net472</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <AssemblyTitle>TypesVisualizer</AssemblyTitle>
+    <Company>FEI Electron Optics</Company>
+    <Product>TypesVisualizer</Product>
+    <Copyright>Copyright © FEI Electron Optics 2017</Copyright>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+  
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <ProjectReference Include="..\..\DgmlBuilder\DgmlBuilder.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Reflection\ExcludeByCustomAttribute.cs" />
-    <Compile Include="Reflection\ExcludeByNameSpace.cs" />
-    <Compile Include="Reflection\IExcludeFilter.cs" />
-    <Compile Include="Reflection\TypesLoader.cs" />
-    <Compile Include="TypesVisualizer.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\DgmlBuilder\DgmlBuilder.csproj">
-      <Project>{582e63a3-5b1c-4e05-8bfc-8468ce62b32e}</Project>
-      <Name>DgmlBuilder</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/examples/TypesVisualizer/packages.config
+++ b/src/examples/TypesVisualizer/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
-</packages>


### PR DESCRIPTION
Note that I also updated the `csproj` files for the library to target .NET Standard 2.0 instead of multi-targeting, as well as upgrading the example app to the new SDK project format and targeting .NET 4.7.2 (which can consume .NET Standard 2.0 without additional libraries/configuration). These seem somewhat optional, but I found them to simplify what was there. This means the NuGet package would now change from .NET Framework version 4.5 minimum to version 4.6.1. The changes to the `Model` namespace should work fine without these changes if you don't want them.